### PR TITLE
Avoid implicit event loop lookup in protocol tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ class FstrmClientProtocol(asyncio.Protocol):
         payload = self.fstrm.encode_data(data)
         self.transport.write(payload)
 
-async def run(loop):
+async def run():
+    loop = asyncio.get_running_loop()
+
     # Create server and client
     data_recv = loop.create_future()
     hanshake_server = loop.create_future()
@@ -106,6 +108,5 @@ async def run(loop):
     transport.close()
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(run(loop))
+    asyncio.run(run())
 ```

--- a/tests/protocol.py
+++ b/tests/protocol.py
@@ -60,7 +60,12 @@ class FstrmClientProtocol(asyncio.Protocol):
 
 class TestClientServer(unittest.TestCase):
     def setUp(self):
-        self.loop = asyncio.get_event_loop()
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
+
+    def tearDown(self):
+        self.loop.close()
+        asyncio.set_event_loop(None)
 
     def test1_handshake(self):
         """do handshake"""


### PR DESCRIPTION
Fixes #2.

Summary:
- Create an explicit event loop for the protocol unittest and close it in teardown.
- Update the README example to use `asyncio.run()` with `asyncio.get_running_loop()` inside the coroutine.
- Remove the remaining `asyncio.get_event_loop()` usages from the repository.

Validation:
- `git diff --check HEAD~1..HEAD`
- `rg -n asyncio\.get_event_loop .`
- Not run locally: unittest suite, package build, import/runtime check